### PR TITLE
vercel config

### DIFF
--- a/api/detect-cms.js
+++ b/api/detect-cms.js
@@ -1,0 +1,57 @@
+const axios = require('axios');
+
+const CMS_RULES = [
+  {
+    name: 'WordPress',
+    confidence: 0.9,
+    match: (html, headers) =>
+      /wp-content|wp-json|<meta[^>]*WordPress/i.test(html) ||
+      (headers['x-generator'] && /WordPress/i.test(headers['x-generator'])),
+  },
+  {
+    name: 'Drupal',
+    confidence: 0.85,
+    match: (html, headers) =>
+      /drupal\.js|\/sites\/default\//i.test(html) ||
+      (headers['x-generator'] && /Drupal/i.test(headers['x-generator'])),
+  },
+  {
+    name: 'PrestaShop',
+    confidence: 0.8,
+    match: (html, headers) =>
+      /PrestaShop|\/themes\/classic\//i.test(html),
+  },
+  {
+    name: 'Shopify',
+    confidence: 0.8,
+    match: (html, headers) =>
+      /cdn\.shopify\.com/i.test(html),
+  },
+  {
+    name: 'Magento',
+    confidence: 0.8,
+    match: (html, headers) =>
+      /mage-cache-sessid|\/static\/frontend\//i.test(html),
+  },
+];
+
+module.exports = async (req, res) => {
+  if (req.method !== 'POST') {
+    return res.status(405).json({ error: 'Método no permitido' });
+  }
+  const { url } = req.body;
+  if (!url) {
+    return res.status(400).json({ error: 'URL requerida' });
+  }
+  try {
+    const { data: html, headers } = await axios.get(url, { timeout: 7000 });
+    for (const rule of CMS_RULES) {
+      if (rule.match(html, headers)) {
+        return res.json({ cms: rule.name, confidence: rule.confidence });
+      }
+    }
+    return res.json({ cms: 'Desconocido', confidence: 0.1 });
+  } catch (e) {
+    return res.json({ cms: 'Desconocido', confidence: 0 });
+  }
+};

--- a/api/package.json
+++ b/api/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "api",
+  "version": "1.0.0",
+  "main": "detect-cms.js",
+  "dependencies": {
+    "axios": "^1.6.8"
+  }
+}

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -1,5 +1,5 @@
 export async function detectCMS(url: string): Promise<{ cms: string; confidence: number }> {
-  const res = await fetch('http://localhost:4000/api/detect', {
+  const res = await fetch('/api/detect', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ url })

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,11 @@
+{
+  "version": 2,
+  "builds": [
+    { "src": "frontend/package.json", "use": "@vercel/static-build", "config": { "distDir": "dist" } },
+    { "src": "api/detect-cms.js", "use": "@vercel/node" }
+  ],
+  "routes": [
+    { "src": "/api/detect", "dest": "/api/detect-cms.js" },
+    { "src": "/(.*)", "dest": "/frontend/dist/$1" }
+  ]
+}


### PR DESCRIPTION
This pull request introduces a backend API for CMS detection, integrates it with the frontend, and adds deployment configuration for Vercel. The main changes include creating a Node.js API endpoint to detect popular CMSs, updating the frontend to use this new endpoint, and configuring the project for serverless deployment.

**Backend: CMS Detection API**
- Added `api/detect-cms.js`: Implements a Node.js API endpoint that inspects a given URL for signs of WordPress, Drupal, PrestaShop, Shopify, or Magento, returning the detected CMS and a confidence score. Uses `axios` for HTTP requests.
- Added `api/package.json`: Specifies dependencies (notably `axios`) for the API function.

**Frontend Integration**
- Updated `frontend/src/api.ts`: Changed the CMS detection API call to use the new relative `/api/detect` endpoint, enabling seamless communication with the backend function.

**Deployment Configuration**
- Added `vercel.json`: Configures Vercel to deploy the frontend as a static site and the CMS detection API as a serverless function. Also sets up routing so that `/api/detect` is handled by the backend and all other routes go to the frontend.